### PR TITLE
Made CodeMirror viewportMargin: Infinity

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -37,6 +37,7 @@
 			cursorScrollMargin: 12,
 			showTrailingSpace: true,
 			styleActiveLine: true,
+			viewportMargin: Infinity
 		});
 
 		editor.setSize('100%', '100%');

--- a/src/syntax/syntax.js
+++ b/src/syntax/syntax.js
@@ -185,22 +185,30 @@ function findSyntaxErrors(text) {
 							embed = json;
 						}
 
-						for(let j = 0 ; j < embed.fields.length; j++) {
-							if(embed.fields[j].name.trim().length == 0) {
-								results.push({
-									line: i + 1,
-									type: "error",
-									text: "JSON embed object is invalid: \"name\" is empty in an embed field"
-								});
-							}
-							if(embed.fields[j].value.trim() == 0) {
-								results.push({
-									line: i + 1,
-									type: "error",
-									text: "JSON embed object is invalid: \"value\" is empty in an embed field"
-								});
+						try {
+							if(embed.fields) {
+								for(let j = 0 ; j < embed.fields.length; j++) {
+									if(embed.fields[j].name.trim().length == 0) {
+										results.push({
+											line: i + 1,
+											type: "error",
+											text: "JSON embed object is invalid: \"name\" is empty in an embed field"
+										});
+									}
+									if(embed.fields[j].value.trim() == 0) {
+										results.push({
+											line: i + 1,
+											type: "error",
+											text: "JSON embed object is invalid: \"value\" is empty in an embed field"
+										});
+									}
+								}
 							}
 						}
+						
+					catch(e) {
+						console.log("Error parsing embed fields: " + e);
+					}
 
 						// TODO: validate embed object
                         const embedValid = validateEmbedSchema(results, i + 1, embed);


### PR DESCRIPTION
Setting the CodeMirror viewportMargin to infinity allows the use of ctrl+f to find instances in the CodeMirror, even without the instance being in the current viewable portion as it currently does. 
https://github.com/codemirror/codemirror5/issues/4491 <- where I got the idea from.
They say it can impact page load time but I didn't notice anything using the Vorago guide, and I think the ctrl+f is more valuable than page load time anyway *if* it actually has a noticeable impact.