### PR TITLE
Add support for loading a guide based on URL param

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -18,13 +18,13 @@
 	import autoformatText from './editor/autoformat';  
 	import { populateConstants } from './pvmeSettings';
 	import { text } from './stores';
-	import Modal from './modal.svelte'
 
 
 	let editor;
 	let validText = $text;	//  bug: exiting last session with invalid text
 	let showView = true;
   let scrollBottom = false;
+  let guideUrl = '';
 
 	onMount(async ()=>{
 		editor = CodeMirror.fromTextArea(document.getElementById('input'), {
@@ -56,19 +56,25 @@
 			'Tab': 'autoIndentMarkdownList',
 			'Shift-Tab': 'autoUnindentMarkdownList'
 		});
-		let showModal = false;
+		editor.setValue($text);
+		validateText();
 		const urlParams = new URLSearchParams(window.location.search);
 		if(urlParams.has('id')) {
 			const channelsJSON = await rawGithubJSONRequest('https://raw.githubusercontent.com/pvme/pvme-settings/pvme-discord/channels.json');
 			for(const channel of channelsJSON) {
 				if(channel.id === urlParams.get('id')) {
-					editor.setValue(await rawGithubTextRequest(`https://raw.githubusercontent.com/pvme/pvme-guides/master/${channel.path}`));
+					//showModal = true;
+					guideUrl = `https://raw.githubusercontent.com/pvme/pvme-guides/master/${channel.path}`;
+					if(window.confirm(`Click confirm to overwrite your current progress with the ${channel.name} guide`)) {
+						loadGuide();
+					}
+					
 					break;
 				}
 			}
 		}
-		editor.setValue($text);
-		validateText();
+		
+		
 	});
 	
 	function newInput(cm, change) {
@@ -144,6 +150,9 @@ async function rawGithubTextRequest(url) {
 async function rawGithubJSONRequest(url) {
     const res = await rawGithubGetRequest(url);
     return await res.json();
+}
+export async function loadGuide() {
+	editor.setValue(await rawGithubTextRequest(guideUrl));
 }
 </script>
 


### PR DESCRIPTION
Aloooooo
Based on some requests from the editing team I've implemented a crude way to have a specific guide get auto-loaded into the guide editor by following a URL with a query param matching the discord channel ID.

The ideal use-case for this will be to have the PvME Util Bot use a new command called /files similar to the existing command for /guides.

The /files command will output the github URL for the given discord guide, as well as a URL for the guide editor which will auto load the txt into the CodeMirror editor. A very basic confirmation popup occurs as well, asking the user if they are okay with overwriting their current changes with the guide.