### PR TITLE
fix export breaking on encodeURI

### DIFF
--- a/src/components/toolbar/ExportToTxt.svelte
+++ b/src/components/toolbar/ExportToTxt.svelte
@@ -4,17 +4,17 @@
   function exportText() {
     const file = new File([$text], 'GuideEditorExport.txt', {
         type: 'text/plain',
-    })
-    const link = document.createElement('a')
-    const url = URL.createObjectURL(file)
+    });
+    const link = document.createElement('a');
+    const url = URL.createObjectURL(file);
 
-    link.href = url
-    link.download = file.name
-    document.body.appendChild(link)
-    link.click()
+    link.href = url;
+    link.download = file.name;
+    document.body.appendChild(link);
+    link.click();
 
-    document.body.removeChild(link)
-    window.URL.revokeObjectURL(url)
+    document.body.removeChild(link);
+    window.URL.revokeObjectURL(url);
   }
 </script>
 

--- a/src/components/toolbar/ExportToTxt.svelte
+++ b/src/components/toolbar/ExportToTxt.svelte
@@ -2,11 +2,19 @@
   import { text } from './../../stores'; 
 
   function exportText() {
-    let hiddenElement = document.createElement('a');
-    hiddenElement.href = 'data:attachment/text,' + encodeURI($text);
-    hiddenElement.target = '_blank';
-    hiddenElement.download = 'GuideEditorExport.txt';
-    hiddenElement.click();
+    const file = new File([$text], 'GuideEditorExport.txt', {
+        type: 'text/plain',
+    })
+    const link = document.createElement('a')
+    const url = URL.createObjectURL(file)
+
+    link.href = url
+    link.download = file.name
+    document.body.appendChild(link)
+    link.click()
+
+    document.body.removeChild(link)
+    window.URL.revokeObjectURL(url)
   }
 </script>
 


### PR DESCRIPTION
Old method was crude and outdated. It ended up chopping the file at the first "#" which caused a lot of issues.
New method is better and as a side effect, supports more browsers.