### PR TITLE
fix longstanding bug with query param removal

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -131,7 +131,7 @@
 	    if(window.confirm(`Click confirm to overwrite your current progress with the ${channel.name} guide`)) {
 		  editor.setValue(await rawGithubTextRequest(guideUrl));
 		  // remove /?id= when loading a guide from ID
-		  window.history.pushState({}, document.title, "/" + "");
+		  window.history.pushState({}, document.title, "/guide-editor");
 		}
 		break;
 	  }


### PR DESCRIPTION
ever since automatic guide loading was added with the ?id={discordchannelid} formatting, upon loading the guide it nukes the entire URL down to just pvme.io instead of pvme.io/guide-editor
this meant if the user refreshed the page, or went inactive and came back after chrome placed the tab in hibernation, their tab would magically go to pvme.io instead
this fixes that by leaving the /guide-editor part