### PR TITLE
throw error if emoji inside a link

### DIFF
--- a/src/syntax/syntax.js
+++ b/src/syntax/syntax.js
@@ -307,6 +307,16 @@ function findSyntaxErrors(text) {
 			message.text = "\u200b";
 		}
 
+		const linkWithDiscordEmoji = /\[[^\]]*<a?:\w+:\d+>[^\]]*\]\([^)]+\)/g;
+
+		if (linkWithDiscordEmoji.test(message.text)) {
+			results.push({
+				line: [message.firstline, message.lastline],
+				type: "error",
+				text: "Discord emoji must not appear inside markdown link text"
+			});
+		}
+
 		if (message.text.length > 2000) {
 			results.push({
 				line: [ message.firstline, message.lastline ],


### PR DESCRIPTION
<img width="794" height="479" alt="image" src="https://github.com/user-attachments/assets/c39001ea-5491-4595-a731-845f8fada08b" />
